### PR TITLE
:adhesive_bandage:  Enable IDLE hook & power savings

### DIFF
--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -33,7 +33,7 @@ class demos(ConanFile):
             self.requires("libhal-armcortex/[^2.1.0]")
             self.requires("libhal-lpc40/[^2.1.1]")
         self.requires("libhal-freertos/10.6.0", options={
-            "configUSE_IDLE_HOOK": False
+            "configUSE_IDLE_HOOK": True
         })
         self.requires("libhal-util/[^3.0.0]")
 

--- a/demos/platforms/lpc4078.cpp
+++ b/demos/platforms/lpc4078.cpp
@@ -59,6 +59,24 @@ void usage_fault_handler()
   }
 }
 
+extern "C"
+{
+  void vPortSetupTimerInterrupt(void)
+  {
+    auto& clock = hal::lpc40::clock::get();
+    auto cpu_frequency = clock.get_frequency(hal::lpc40::peripheral::cpu);
+    static hal::cortex_m::systick_timer systick(cpu_frequency);
+    if (!systick.schedule(xPortSysTickHandler, 1ms)) {
+      hal::halt();
+    }
+  }
+
+  void vApplicationIdleHook()
+  {
+    asm volatile("wfi");
+  }
+}
+
 hal::status initialize_processor()
 {
   hal::cortex_m::initialize_data_section();

--- a/demos/platforms/stm32f103c8.cpp
+++ b/demos/platforms/stm32f103c8.cpp
@@ -80,8 +80,7 @@ extern "C"
 
   void vApplicationIdleHook()
   {
-    // asm volatile("wfi");
-    taskYIELD();
+    asm volatile("wfi");
   }
 }
 


### PR DESCRIPTION
- Call WFI instruction to enter power savings when the idle task is
  running.
- Override systick setup in lpc4078 as the built in systick handler
  can result in, incorrect tick timing.